### PR TITLE
Update links to nodejs 4.0.0

### DIFF
--- a/automatic/nodejs.commandline/tools/chocolateyInstall.ps1
+++ b/automatic/nodejs.commandline/tools/chocolateyInstall.ps1
@@ -1,6 +1,6 @@
 ﻿$packageName = 'nodejs'
-$url = 'http://nodejs.org/dist/v{{PackageVersion}}/node.exe'
-$url64 = 'http://nodejs.org/dist/v{{PackageVersion}}/x64/node.exe'
+$url = 'https://nodejs.org/dist/v{{PackageVersion}}/win-x86/node.exe'
+$url64 = 'https://nodejs.org/dist/v{{PackageVersion}}/win-x64/node.exe'
 
 try {
   $installDir = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"

--- a/automatic/nodejs.install/tools/chocolateyInstall.ps1
+++ b/automatic/nodejs.install/tools/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$packageName = 'nodejs.install'
 $installerType = 'msi'
-$url = 'http://nodejs.org/dist/v{{PackageVersion}}/node-v{{PackageVersion}}-x86.msi'
-$url64 = 'http://nodejs.org/dist/v{{PackageVersion}}/x64/node-v{{PackageVersion}}-x64.msi'
+$url = 'https://nodejs.org/dist/v{{PackageVersion}}/node-v{{PackageVersion}}-x86.msi'
+$url64 = 'https://nodejs.org/dist/v{{PackageVersion}}/node-v{{PackageVersion}}-x64.msi'
 $silentArgs = '/quiet'
 $validExitCodes = @(0)
 


### PR DESCRIPTION
Probably the sligthly different schema in the download URL's might be the problem that there is no nodejs Chocolatey package for version 4.0.0.

Signed-off-by: Stefan Scherer <scherer_stefan@icloud.com>